### PR TITLE
Update examples to use ConstraintLayout 2.0.0 beta 3 release

### DIFF
--- a/ConstraintLayoutExamples/build.gradle
+++ b/ConstraintLayoutExamples/build.gradle
@@ -20,24 +20,25 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
 
     ext {
-        compileSdkVersion = 28
-        targetSdkVersion = 28
+        compileSdkVersion = 29
+        targetSdkVersion = 29
 
         appCompatVersion = '1.1.0-alpha03'
-        constraintLayoutVersion = '2.0.0-beta1'
-        glideVersion = '4.8.0'
-        kotlinVersion = '1.3.11'
+        constraintLayoutVersion = '2.0.0-beta3'
+        glideVersion = '4.9.0'
+        kotlinVersion = '1.3.60-eap-25'
         lifeCycleVersion = '2.0.0'
-        lottieVersion = '2.5.1'
-        materialVersion = '1.1.0-alpha05'
+        lottieVersion = '3.1.0'
+        materialVersion = '1.2.0-alpha01'
         junitVersion = '4.12'
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:4.0.0-alpha01'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -49,6 +50,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
 }
 

--- a/ConstraintLayoutExamples/gradle/wrapper/gradle-wrapper.properties
+++ b/ConstraintLayoutExamples/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Nov 16 15:14:01 JST 2018
+#Wed Oct 23 20:02:10 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-all.zip

--- a/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/fragmentsdemo/FragmentExample2Activity.kt
+++ b/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/fragmentsdemo/FragmentExample2Activity.kt
@@ -72,10 +72,6 @@ class FragmentExample2Activity: AppCompatActivity(), View.OnClickListener, Motio
     override fun onTransitionCompleted(p0: MotionLayout?, p1: Int) {
     }
 
-    override fun allowsTransition(p0: MotionScene.Transition?): Boolean {
-        return true
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.main_activity)

--- a/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/fragmentsdemo/FragmentExampleActivity.kt
+++ b/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/fragmentsdemo/FragmentExampleActivity.kt
@@ -72,10 +72,6 @@ class FragmentExampleActivity : AppCompatActivity(), View.OnClickListener, Motio
     override fun onTransitionCompleted(p0: MotionLayout?, p1: Int) {
     }
 
-    override fun allowsTransition(p0: MotionScene.Transition?): Boolean {
-        return true
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.main_activity)


### PR DESCRIPTION
Built the sample app with updated dependencies.

There is one change I've noticed as a difference from Beta 2: all `Complex Motion` examples have a jittery-ness to them. You can reproduce this by scrolling to the bottom of the content and then attempting to scroll up - you'll notice that the header seems to be trying to expand but this animation appears to be repeatedly canceled until the user gets to the top of the content.

I think this should still be merged anyway because its just the current state of ConstraintLayout.