### PR TITLE
Reproduce onTransitionCompleted bug

### DIFF
--- a/ConstraintLayoutExamples/build.gradle
+++ b/ConstraintLayoutExamples/build.gradle
@@ -27,7 +27,7 @@ buildscript {
         targetSdkVersion = 28
 
         appCompatVersion = '1.1.0-alpha03'
-        constraintLayoutVersion = '2.0.0-beta3'
+        constraintLayoutVersion = '2.0.0-beta6'
         glideVersion = '4.8.0'
         kotlinVersion = '1.3.71'
         lifeCycleVersion = '2.0.0'

--- a/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/DemoActivity.kt
+++ b/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/DemoActivity.kt
@@ -18,6 +18,7 @@ package com.google.androidstudio.motionlayoutexample
 
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.widget.ImageView
 import androidx.annotation.RequiresApi
@@ -45,7 +46,37 @@ class DemoActivity : AppCompatActivity() {
         } else {
             MotionLayout.DEBUG_SHOW_NONE
         }
-        (container as? MotionLayout)?.setDebugMode(debugMode)
+        (container as? MotionLayout)?.apply {
+            setDebugMode(debugMode)
+            setTransitionListener(object : MotionLayout.TransitionListener {
+                override fun onTransitionTrigger(
+                    motionLayout: MotionLayout,
+                    triggerId: Int,
+                    positive: Boolean,
+                    progress: Float
+                ) = Unit
+
+                override fun onTransitionStarted(
+                    motionLayout: MotionLayout,
+                    startId: Int,
+                    endId: Int
+                ) = Unit
+
+                override fun onTransitionChange(
+                    motionLayout: MotionLayout,
+                    startId: Int,
+                    endId: Int,
+                    progress: Float
+                ) = Unit
+
+                override fun onTransitionCompleted(motionLayout: MotionLayout, currentId: Int) {
+                    Log.d(
+                        "DemoActivity",
+                        "$currentId: currentId is start: ${currentId == R.id.start}, currentId is end: ${currentId == R.id.end}"
+                    )
+                }
+            })
+        }
     }
 
     fun changeState(v: View?) {


### PR DESCRIPTION
This PR reproduces an issue with `MotionLayout.TransitionListener` in `2.0.0-beta5` and `2.0.0-beta6`.

In `Complex Motion Example (4/4)`, the `onTransitionCompleted` method is called multiple times, and sometimes with a `currentId` of `-1`, which is unexpected:

Clicking the button once results in an output of
```
2020-05-19 15:02:44.355 30563-30563/com.google.androidstudio.motionlayoutexample D/DemoActivity: 2131230886: currentId is start: false, currentId is end: true
2020-05-19 15:02:44.355 30563-30563/com.google.androidstudio.motionlayoutexample D/DemoActivity: -1: currentId is start: false, currentId is end: false
2020-05-19 15:02:44.355 30563-30563/com.google.androidstudio.motionlayoutexample D/DemoActivity: 2131230886: currentId is start: false, currentId is end: true
```

Reverting to `2.0.0-beta4` gives the expected output:
```
2020-05-19 15:03:58.180 30885-30885/com.google.androidstudio.motionlayoutexample D/DemoActivity: 2131230883: currentId is start: false, currentId is end: true
```