### PR TITLE
Adds a class to determine which JS-Java API to use

### DIFF
--- a/WebView/app/build.gradle
+++ b/WebView/app/build.gradle
@@ -22,6 +22,11 @@ android {
     compileSdkVersion 29
     buildToolsVersion "29.0.3"
 
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
+
     defaultConfig {
         applicationId "com.android.samples.webviewdemo"
         minSdkVersion 21
@@ -53,7 +58,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
     implementation "androidx.core:core-ktx:$core_ktx_version"
     implementation "androidx.fragment:fragment-ktx:$fragment_ktx_version"
-    implementation "androidx.webkit:webkit:$webkit_version"
+    implementation "androidx.webkit:webkit:1.3.0-beta01"
 
     implementation "com.google.android.material:material:$material_components_version"
 

--- a/WebView/app/build.gradle
+++ b/WebView/app/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
     implementation "androidx.core:core-ktx:$core_ktx_version"
     implementation "androidx.fragment:fragment-ktx:$fragment_ktx_version"
-    implementation "androidx.webkit:webkit:1.3.0-beta01"
+    implementation "androidx.webkit:webkit:1.3.0-rc01"
 
     implementation "com.google.android.material:material:$material_components_version"
 

--- a/WebView/app/build.gradle
+++ b/WebView/app/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
     implementation "androidx.core:core-ktx:$core_ktx_version"
     implementation "androidx.fragment:fragment-ktx:$fragment_ktx_version"
-    implementation "androidx.webkit:webkit:1.3.0-rc01"
+    implementation "androidx.webkit:webkit:$webkit_version"
 
     implementation "com.google.android.material:material:$material_components_version"
 

--- a/WebView/app/src/main/assets/main.js
+++ b/WebView/app/src/main/assets/main.js
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 function sendAndroidMessage() {
+    /* In this implementation, only the single-arg version of postMessage is supported. As noted
+     * in the WebViewCompat reference doc, the second parameter, MessagePorts, is optional.
+     * Also note that onmessage, addEventListener and removeEventListener are not supported.
+     */
 	jsObject.postMessage("The weather in " + `${document.getElementById("title").innerText}` + " today is " +
 	`${document.getElementById("shortDescription").innerText} `);
 }

--- a/WebView/app/src/main/assets/main.js
+++ b/WebView/app/src/main/assets/main.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 function sendAndroidMessage() {
-	Weather.sendMessage("The weather in " + `${document.getElementById("title").innerText}` + " today is " + 
+	jsObject.postMessage("The weather in " + `${document.getElementById("title").innerText}` + " today is " +
 	`${document.getElementById("shortDescription").innerText} `);
 }
 

--- a/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
+++ b/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
@@ -82,19 +82,16 @@ class MainActivity : AppCompatActivity() {
     /** Instantiate a class to determine which JS-Java API to use based on the version the application is running on */
     class JsObject() {
         fun createJsObject(webview : WebView , context: Context) {
-            // If the application is running on a version that supports WebMessageListener then use it.
-            // WebMessageListener is preferred because it is more secure
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                // The JavaScript object will be injected in any frame whose origin matches one in the list created below.
-                // We call the list rules because this is a set of allowed origin rules
-                val rules = setOf<String>("https://gcoleman799.github.io")
-                if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) WebViewCompat.addWebMessageListener(
-                    webview,
-                    "myObject",
-                    rules,
-                    MyListener()
+            // The JavaScript object will be injected in any frame whose origin matches one in the list created below.
+            // We call the list rules because this is a set of allowed origin rules
+            val rules = setOf<String>("https://gcoleman799.github.io")
+            if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) WebViewCompat.addWebMessageListener(
+                webview,
+                "myObject",
+                rules,
+                MyListener()
                 )
-            } else {
+            else {
             // Falls back to JavascriptInterface if the application is running on a lower API level
             webview.addJavascriptInterface(WebAppInterface(context), "myObject") }
         }
@@ -137,7 +134,7 @@ class MainActivity : AppCompatActivity() {
 
         // Create a JS object to be injected into frames; regardless of which API is used
         // (WebMessageListener or WebAppInterface) the JS object will be named myObject in this case.
-        JsObject().createJsObject(binding.webview, this)
+        MainActivity.JsObject().createJsObject(binding.webview, this)
 
         // Load the content
         binding.webview.loadUrl("https://gcoleman799.github.io/Asset-Loader/assets/index.html")

--- a/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
+++ b/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
@@ -91,13 +91,13 @@ class MainActivity : AppCompatActivity() {
                 // Adds myListener to webview and injects a JavaScript object into each frame that myListener will listen on
                 if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) WebViewCompat.addWebMessageListener(
                     webview,
-                    "myObject1",
+                    "myObject",
                     rules,
                     MyListener()
                 )
-            }
+            } else {
             //Falls back to JavascriptInterface if WebMessageListener is not available
-            webview.addJavascriptInterface(WebAppInterface(context), "myObject2")
+            webview.addJavascriptInterface(WebAppInterface(context), "myObject") }
         }
     }
 

--- a/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
+++ b/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
@@ -38,6 +38,8 @@ import androidx.webkit.WebViewFeature
 import com.android.samples.webviewdemo.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
+    val jsObjName = "jsObject"
+
     // Creating the custom WebView Client Class
     private class MyWebViewClient(private val assetLoader: WebViewAssetLoader) :
         WebViewClientCompat() {
@@ -66,7 +68,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     /** Instantiate the Listener  */
-    class MyListener() : WebViewCompat.WebMessageListener {
+    class WebMessageListener() : WebViewCompat.WebMessageListener {
         override fun onPostMessage(
             view: WebView,
             message: WebMessageCompat,
@@ -79,23 +81,23 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    /** Instantiate a class to determine which JS-Java API to use based on the version the application is running on */
-    class JsObject() {
-        fun createJsObject(webview : WebView , context: Context) {
-            // The JavaScript object will be injected in any frame whose origin matches one in the list created below.
-            // We call the list rules because this is a set of allowed origin rules
-            val rules = setOf<String>("https://gcoleman799.github.io")
-            if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) WebViewCompat.addWebMessageListener(
-                webview,
-                "myObject",
-                rules,
-                MyListener()
-                )
-            else {
+
+    private fun createJsObject(webview: WebView, context: Context) {
+        // The JavaScript object will be injected in any frame whose origin matches one in the list created below.
+        // We call the list rules because this is a set of allowed origin rules
+        val rules = setOf<String>("https://gcoleman799.github.io")
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) WebViewCompat.addWebMessageListener(
+            webview,
+            jsObjName,
+            rules,
+            WebMessageListener()
+        )
+        else {
             // Falls back to JavascriptInterface if the application is running on a lower API level
-            webview.addJavascriptInterface(WebAppInterface(context), "myObject") }
+            webview.addJavascriptInterface(WebAppInterface(context), jsObjName)
         }
     }
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -134,7 +136,7 @@ class MainActivity : AppCompatActivity() {
 
         // Create a JS object to be injected into frames; regardless of which API is used
         // (WebMessageListener or WebAppInterface) the JS object will be named myObject in this case.
-        MainActivity.JsObject().createJsObject(binding.webview, this)
+        createJsObject(binding.webview, this)
 
         // Load the content
         binding.webview.loadUrl("https://gcoleman799.github.io/Asset-Loader/assets/index.html")

--- a/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
+++ b/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
@@ -84,7 +84,7 @@ class MainActivity : AppCompatActivity() {
         fun createJsObject(webview : WebView , context: Context) {
             // If the application is running on a version that supports WebMessageListener then use it.
             // WebMessageListener is preferred because it is more secure
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 // The JavaScript object will be injected in any frame whose origin matches one in the list created below.
                 // We call the list rules because this is a set of allowed origin rules
                 val rules = setOf<String>("https://gcoleman799.github.io")
@@ -95,7 +95,7 @@ class MainActivity : AppCompatActivity() {
                     MyListener()
                 )
             } else {
-            //Falls back to JavascriptInterface if the application is running on a lower API level
+            // Falls back to JavascriptInterface if the application is running on a lower API level
             webview.addJavascriptInterface(WebAppInterface(context), "myObject") }
         }
     }

--- a/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
+++ b/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
@@ -1,18 +1,18 @@
 /*
-* Copyright (C) 2020 The Android Open Source Project
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*      http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.android.samples.webviewdemo
 
@@ -118,8 +118,7 @@ class MainActivity : AppCompatActivity() {
             type = "text/plain"
         }
         val shareIntent = Intent.createChooser(sendIntent, null)
-        // Below, the first parameter, this, refers to the context of MainActivity
-        startActivity(this, shareIntent, null)
+        startActivity(this@MainActivity, shareIntent, null)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
+++ b/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
@@ -80,15 +80,14 @@ class MainActivity : AppCompatActivity() {
     }
 
     /** Instantiate a class to determine which JS-Java API to use based on the version the application is running on */
-    class ApiVersion() {
-        fun determineVersion(webview : WebView , context: Context) {
-            //Checks to see if the API the applicatoin is running on is high enough to support the new API
+    class JsObject() {
+        fun createJsObject(webview : WebView , context: Context) {
+            // If the application is running on a version that supports WebMessageListener then use it.
+            // WebMessageListener is preferred because it is more secure
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 // The JavaScript object will be injected in any frame whose origin matches one in the list created below.
                 // We call the list rules because this is a set of allowed origin rules
                 val rules = setOf<String>("https://gcoleman799.github.io")
-
-                // Adds myListener to webview and injects a JavaScript object into each frame that myListener will listen on
                 if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) WebViewCompat.addWebMessageListener(
                     webview,
                     "myObject",
@@ -96,7 +95,7 @@ class MainActivity : AppCompatActivity() {
                     MyListener()
                 )
             } else {
-            //Falls back to JavascriptInterface if WebMessageListener is not available
+            //Falls back to JavascriptInterface if the application is running on a lower API level
             webview.addJavascriptInterface(WebAppInterface(context), "myObject") }
         }
     }
@@ -136,8 +135,9 @@ class MainActivity : AppCompatActivity() {
         // Enable Javascript
         binding.webview.settings.javaScriptEnabled = true
 
-        //create JS object to be injected into frames
-        val myObject = ApiVersion().determineVersion(binding.webview, this)
+        // Create a JS object to be injected into frames; regardless of which API is used
+        // (WebMessageListener or WebAppInterface) the JS object will be named myObject in this case.
+        JsObject().createJsObject(binding.webview, this)
 
         // Load the content
         binding.webview.loadUrl("https://gcoleman799.github.io/Asset-Loader/assets/index.html")

--- a/WebView/app/src/main/res/layout/activity_main.xml
+++ b/WebView/app/src/main/res/layout/activity_main.xml
@@ -19,8 +19,7 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context=".MainActivity"
-    android:configChanges="uiMode">
+    tools:context=".MainActivity">
 
     <WebView
         android:id="@+id/webview"

--- a/WebView/app/src/main/res/layout/activity_main.xml
+++ b/WebView/app/src/main/res/layout/activity_main.xml
@@ -19,7 +19,8 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context=".MainActivity">
+    tools:context=".MainActivity"
+    android:configChanges="uiMode">
 
     <WebView
         android:id="@+id/webview"

--- a/WebView/build.gradle
+++ b/WebView/build.gradle
@@ -24,7 +24,7 @@ buildscript {
         fragment_ktx_version = '1.2.4'
         kotlin_version = '1.3.72'
         material_components_version = '1.1.0'
-        webkit_version = '1.2.0'
+        webkit_version = '1.3.0-rc01'
     }
     repositories {
         google()


### PR DESCRIPTION
This PR creates a new class in MainActivity.kt called 'JSObject'. If the API level of the device the application is running on is above Q then WebMessageListener will be used. Otherwise the application will defer to WebAppInterface. In either case, when the  createJSObject function from the JSObject class is called a JS object called myObject is created. In this PR, the JS function sendAnroidMessage() prints out the JS Object 'myObject'. 

The object that is created on an a device with an API below Q is: 
<img width="302" alt="Screen Shot 2020-07-06 at 1 09 45 PM" src="https://user-images.githubusercontent.com/50959941/86620222-f9c3b980-bf89-11ea-9766-c9c82a04a4cd.png">


The object that is created on an a device with an API Q or above is:
<img width="299" alt="Screen Shot 2020-07-06 at 1 11 37 PM" src="https://user-images.githubusercontent.com/50959941/86620383-3b546480-bf8a-11ea-8a77-272061ece266.png">

