### PR TITLE
adds force dark compatability

### DIFF
--- a/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
+++ b/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
@@ -131,7 +131,7 @@ class MainActivity : AppCompatActivity() {
         val allowedOriginRules = setOf<String>("https://gcoleman799.github.io")
 
         // Check if the system is set to light or dark mode
-        val nightModeFlag = resources.configuration.uiMode.and(Configuration.UI_MODE_NIGHT_MASK)
+        val nightModeFlag = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
         if (nightModeFlag == Configuration.UI_MODE_NIGHT_YES) {
             // Switch WebView to dark mode; uses default dark theme
             if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
@@ -140,6 +140,7 @@ class MainActivity : AppCompatActivity() {
                     WebSettingsCompat.FORCE_DARK_ON
                 )
             }
+            // TODO: set darkening strategy and use custom CSS for dark theme
         }
 
         // Configure asset loader with custom domain

--- a/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
+++ b/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
@@ -16,8 +16,10 @@
 
 package com.android.samples.webviewdemo
 
+import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
+import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -28,9 +30,14 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_YES
 import androidx.core.content.ContextCompat.startActivity
 import androidx.webkit.JavaScriptReplyProxy
 import androidx.webkit.WebMessageCompat
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebSettingsCompat.DARK_STRATEGY_USER_AGENT_DARKENING_ONLY
+import androidx.webkit.WebSettingsCompat.DARK_STRATEGY_WEB_THEME_DARKENING_ONLY
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewClientCompat
 import androidx.webkit.WebViewCompat
@@ -111,7 +118,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     // Invokes native android sharing
-    private fun invokeShareIntent (message: String) {
+    private fun invokeShareIntent(message: String) {
         val sendIntent: Intent = Intent().apply {
             action = Intent.ACTION_SEND
             putExtra(Intent.EXTRA_TEXT, message)
@@ -127,6 +134,19 @@ class MainActivity : AppCompatActivity() {
         setContentView(binding.root)
         val jsObjName = "jsObject"
         val allowedOriginRules = setOf<String>("https://gcoleman799.github.io")
+
+        // Check if the system is set to light or dark mode
+        val nightModeFlag1 = resources.configuration.uiMode
+        val nightModeFlag2 = Configuration.UI_MODE_NIGHT_MASK
+        if (nightModeFlag1.and(nightModeFlag2) == Configuration.UI_MODE_NIGHT_YES) {
+            // Switch WebView to dark mode; uses default dark theme
+            if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+                WebSettingsCompat.setForceDark(
+                    binding.webview.settings,
+                    WebSettingsCompat.FORCE_DARK_ON
+                )
+            }
+        }
 
         // Configure asset loader with custom domain
         // * NOTE THAT *:
@@ -164,7 +184,7 @@ class MainActivity : AppCompatActivity() {
             binding.webview,
             jsObjName,
             allowedOriginRules
-        ) { message ->invokeShareIntent(message)}
+        ) { message -> invokeShareIntent(message) }
 
         // Load the content
         binding.webview.loadUrl("https://gcoleman799.github.io/Asset-Loader/assets/index.html")

--- a/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
+++ b/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
@@ -16,7 +16,6 @@
 
 package com.android.samples.webviewdemo
 
-import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.content.res.Configuration
@@ -30,14 +29,10 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.app.AppCompatDelegate
-import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_YES
 import androidx.core.content.ContextCompat.startActivity
 import androidx.webkit.JavaScriptReplyProxy
 import androidx.webkit.WebMessageCompat
 import androidx.webkit.WebSettingsCompat
-import androidx.webkit.WebSettingsCompat.DARK_STRATEGY_USER_AGENT_DARKENING_ONLY
-import androidx.webkit.WebSettingsCompat.DARK_STRATEGY_WEB_THEME_DARKENING_ONLY
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewClientCompat
 import androidx.webkit.WebViewCompat
@@ -136,9 +131,8 @@ class MainActivity : AppCompatActivity() {
         val allowedOriginRules = setOf<String>("https://gcoleman799.github.io")
 
         // Check if the system is set to light or dark mode
-        val nightModeFlag1 = resources.configuration.uiMode
-        val nightModeFlag2 = Configuration.UI_MODE_NIGHT_MASK
-        if (nightModeFlag1.and(nightModeFlag2) == Configuration.UI_MODE_NIGHT_YES) {
+        val nightModeFlag = resources.configuration.uiMode.and(Configuration.UI_MODE_NIGHT_MASK)
+        if (nightModeFlag == Configuration.UI_MODE_NIGHT_YES) {
             // Switch WebView to dark mode; uses default dark theme
             if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
                 WebSettingsCompat.setForceDark(


### PR DESCRIPTION
This PR implements a workaround so that the WebView component responds directly to the systems Light and Dark mode settings. When the system is set to Dark mode, the WebView uses a default theme. Below are images of the app in both light and dark mode. 

Dark Mode: 
<img width="352" alt="Screen Shot 2020-07-13 at 7 30 36 PM" src="https://user-images.githubusercontent.com/50959941/87363564-6c5f0700-c53f-11ea-8413-c4546f96acef.png">

Light Mode:
<img width="340" alt="Screen Shot 2020-07-13 at 7 30 53 PM" src="https://user-images.githubusercontent.com/50959941/87363567-6ec16100-c53f-11ea-8247-686901ec64fc.png">


