### PR TITLE
Fix Share Feature

### DIFF
--- a/WebView/app/src/main/assets/index.html
+++ b/WebView/app/src/main/assets/index.html
@@ -28,7 +28,7 @@
       <option value="london">London</option>
     </select>
     <h1 id="title">Location</h1>
-    <img alt="weather" class="icon" id="icon" src="https://raw.githubusercontent.com/res/drawable/sunny.png" />
+    <img alt="weather" class="icon" id="icon" src="https://raw.githubusercontent.com/views-widgets-samples/res/drawable/sunny.png" />
     <h2 class="currentTemp" id="currentTemp">Current Temp</h2>
     <h2 class="shortDescription" id="shortDescription">Short Description</h2>
     <p class="longDescription" id="longDescription">Long Description</p>

--- a/WebView/app/src/main/assets/main.js
+++ b/WebView/app/src/main/assets/main.js
@@ -30,7 +30,6 @@ function getData() {
 	}).then(function(data) {
 		var form = document.getElementById("location");
 		var currentLocation = form.options[form.selectedIndex].value;
-		console.log(data[currentLocation].description);
 		document.getElementById("title").innerText = form.options[form.selectedIndex].text;
         document.getElementById("currentTemp").innerText = `${data[currentLocation].currentTemp}`+ "\xB0 F";
         document.getElementById("shortDescription").innerText = data[currentLocation].description;

--- a/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
+++ b/WebView/app/src/main/java/com/android/samples/webviewdemo/MainActivity.kt
@@ -82,6 +82,7 @@ class MainActivity : AppCompatActivity() {
      * origin in this set then it will have the JS object injected into it
      * @param onMessageReceived invoked on UI thread with message passed in from JavaScript postMessage() call
      */
+
     private fun createJsObject(
         webview: WebView,
         jsObjName: String,
@@ -129,8 +130,8 @@ class MainActivity : AppCompatActivity() {
         val binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
         val jsObjName = "jsObject"
-        val allowedOriginRules = setOf<String>("https://gcoleman799.github.io")
-        
+        val allowedOriginRules = setOf<String>("https://raw.githubusercontent.com")
+
         // Configuring Dark Theme
         // *NOTE* : The force dark setting is not persistent. You must call the static
         // method every time your app process is started.


### PR DESCRIPTION
This PR contains 3 changes

- Corrects the address in the set of allowed origins used by WebMessageListener. The path had 
   not been updated when the location of the data source was changed in a previous PR. This was 
   causing a bug in the messaging feature when WebMessageListener was employed.

- Gets rid of an unnecessary log statement

- Changes the path of the image initially loaded in index.html to be accessible by the application 
   and consistent with the image paths used in main.js