### PR TITLE
Migrate kotlin-android-extension to view Binding at motionLayout

### DIFF
--- a/ConstraintLayoutExamples/motionlayout/build.gradle
+++ b/ConstraintLayoutExamples/motionlayout/build.gradle
@@ -18,8 +18,6 @@ apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
 
-apply plugin: 'kotlin-android-extensions'
-
 android {
     compileSdkVersion rootProject.compileSdkVersion
     defaultConfig {
@@ -36,6 +34,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+
+    buildFeatures {
+        viewBinding = true
     }
 }
 

--- a/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/MainActivity.kt
+++ b/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/MainActivity.kt
@@ -6,13 +6,13 @@ import android.widget.CompoundButton
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.androidstudio.motionlayoutexample.databinding.ActivityMainBinding
 import com.google.androidstudio.motionlayoutexample.fragmentsdemo.FragmentExample2Activity
 import com.google.androidstudio.motionlayoutexample.fragmentsdemo.FragmentExampleActivity
 import com.google.androidstudio.motionlayoutexample.histogramdemo.HistogramActivity
 import com.google.androidstudio.motionlayoutexample.viewpagerdemo.ViewPagerActivity
 import com.google.androidstudio.motionlayoutexample.viewpagerdemo.ViewPagerActivity2
 import com.google.androidstudio.motionlayoutexample.youtubedemo.YouTubeDemoActivity
-import kotlinx.android.synthetic.main.activity_main.*
 
 class MainActivity : AppCompatActivity(), CompoundButton.OnCheckedChangeListener {
     private lateinit var recyclerView: RecyclerView
@@ -53,16 +53,17 @@ class MainActivity : AppCompatActivity(), CompoundButton.OnCheckedChangeListener
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        val binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         viewManager = LinearLayoutManager(this)
         viewAdapter = DemosAdapter(dataset)
-        recyclerView = findViewById<RecyclerView>(R.id.recyclerview).apply {
+        recyclerView = binding.recyclerview.apply {
             setHasFixedSize(true)
             layoutManager = viewManager
             adapter = viewAdapter
         }
 
-        showPaths.setOnCheckedChangeListener(this)
+        binding.showPaths.setOnCheckedChangeListener(this)
     }
 
     override fun onCheckedChanged(p0: CompoundButton?, value: Boolean) {

--- a/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/fragmentsdemo/CustomAdapter.kt
+++ b/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/fragmentsdemo/CustomAdapter.kt
@@ -18,19 +18,18 @@ package com.google.androidstudio.motionlayoutexample.fragmentsdemo
 
 import android.graphics.Rect
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.motion.widget.MotionLayout
 import androidx.recyclerview.widget.RecyclerView
 import com.google.androidstudio.motionlayoutexample.R
+import com.google.androidstudio.motionlayoutexample.databinding.ItemLayoutBinding
 
-class CustomAdapter(private val userList: ArrayList<User>): RecyclerView.Adapter<CustomAdapter.ViewHolder>() {
+class CustomAdapter(private val userList: ArrayList<User>) : RecyclerView.Adapter<CustomAdapter.ViewHolder>() {
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.txtName.text = userList[position].name
-        holder.txtTitle.text = userList[position].title
+        holder.binding.txtName.text = userList[position].name
+        holder.binding.txtTitle.text = userList[position].title
         holder.itemView.setOnClickListener {
             val parent = it?.parent?.parent?.parent?.parent
             if (parent is MotionLayout) {
@@ -48,17 +47,14 @@ class CustomAdapter(private val userList: ArrayList<User>): RecyclerView.Adapter
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        val v = LayoutInflater.from(parent.context).inflate(R.layout.item_layout, parent, false)
-        return ViewHolder(v)
+        val binding = ItemLayoutBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ViewHolder(binding)
     }
 
     override fun getItemCount(): Int {
         return userList.size
     }
 
-    class ViewHolder(itemView: View): RecyclerView.ViewHolder(itemView){
-        val txtName = itemView.findViewById(R.id.txtName) as TextView
-        val txtTitle = itemView.findViewById(R.id.txtTitle) as TextView
-    }
+    class ViewHolder(val binding: ItemLayoutBinding) : RecyclerView.ViewHolder(binding.root)
 
 }

--- a/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/fragmentsdemo/FragmentExample2Activity.kt
+++ b/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/fragmentsdemo/FragmentExample2Activity.kt
@@ -20,10 +20,9 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.motion.widget.MotionLayout
-import androidx.constraintlayout.motion.widget.MotionScene
 import androidx.fragment.app.Fragment
 import com.google.androidstudio.motionlayoutexample.R
-import kotlinx.android.synthetic.main.main_activity.*
+import com.google.androidstudio.motionlayoutexample.databinding.MainActivityBinding
 
 class FragmentExample2Activity: AppCompatActivity(), View.OnClickListener, MotionLayout.TransitionListener {
 
@@ -74,7 +73,8 @@ class FragmentExample2Activity: AppCompatActivity(), View.OnClickListener, Motio
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.main_activity)
+        val binding = MainActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         if (savedInstanceState == null) {
 
             fragment = MainFragment.newInstance().also {
@@ -85,7 +85,7 @@ class FragmentExample2Activity: AppCompatActivity(), View.OnClickListener, Motio
         }
         //toggle.setOnClickListener(this)
         //toggleAnimation.setOnClickListener(this)
-        motionLayout.setTransitionListener(this)
+        binding.motionLayout.setTransitionListener(this)
     }
 
     override fun onClick(view: View?) {

--- a/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/fragmentsdemo/FragmentExampleActivity.kt
+++ b/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/fragmentsdemo/FragmentExampleActivity.kt
@@ -20,10 +20,9 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.motion.widget.MotionLayout
-import androidx.constraintlayout.motion.widget.MotionScene
 import androidx.fragment.app.Fragment
 import com.google.androidstudio.motionlayoutexample.R
-import kotlinx.android.synthetic.main.main_activity.*
+import com.google.androidstudio.motionlayoutexample.databinding.MainActivityBinding
 
 class FragmentExampleActivity : AppCompatActivity(), View.OnClickListener, MotionLayout.TransitionListener {
 
@@ -74,7 +73,8 @@ class FragmentExampleActivity : AppCompatActivity(), View.OnClickListener, Motio
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.main_activity)
+        val binding = MainActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         if (savedInstanceState == null) {
             fragment = MainFragment.newInstance().also {
                 supportFragmentManager.beginTransaction()
@@ -82,7 +82,7 @@ class FragmentExampleActivity : AppCompatActivity(), View.OnClickListener, Motio
                     .commitNow()
             }
         }
-        motionLayout.setTransitionListener(this)
+        binding.motionLayout.setTransitionListener(this)
     }
 
     override fun onClick(view: View?) {

--- a/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/fragmentsdemo/ItemFragment.kt
+++ b/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/fragmentsdemo/ItemFragment.kt
@@ -23,6 +23,7 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import com.google.androidstudio.motionlayoutexample.R
+import com.google.androidstudio.motionlayoutexample.databinding.ItemLayoutBinding
 
 class ItemFragment : Fragment() {
 
@@ -32,15 +33,15 @@ class ItemFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View {
-        return inflater.inflate(R.layout.item_layout, container, false)
+        return ItemLayoutBinding.inflate(inflater, container, false).root
     }
 
     private lateinit var myHolder: CustomAdapter.ViewHolder
 
     fun update(holder: CustomAdapter.ViewHolder) {
         myHolder = holder
-        view?.findViewById<TextView>(R.id.txtTitle)?.text = holder.txtTitle.text
-        view?.findViewById<TextView>(R.id.txtName)?.text = holder.txtName.text
+        view?.findViewById<TextView>(R.id.txtTitle)?.text = holder.binding.txtTitle.text
+        view?.findViewById<TextView>(R.id.txtName)?.text = holder.binding.txtName.text
     }
 
     override fun onStart() {

--- a/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/fragmentsdemo/ListFragment.kt
+++ b/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/fragmentsdemo/ListFragment.kt
@@ -25,6 +25,7 @@ import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.androidstudio.motionlayoutexample.R
+import com.google.androidstudio.motionlayoutexample.databinding.Motion22ListFragmentBinding
 
 class ListFragment : Fragment() {
 
@@ -37,7 +38,7 @@ class ListFragment : Fragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View {
         Log.i(ListFragment::class.java.simpleName, "onCreateView, container is $container")
-        return inflater.inflate(R.layout.motion_22_list_fragment, container, false)
+        return Motion22ListFragmentBinding.inflate(inflater, container, false).root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/fragmentsdemo/SecondFragment.kt
+++ b/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/fragmentsdemo/SecondFragment.kt
@@ -21,13 +21,10 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.constraintlayout.motion.widget.MotionLayout
 import androidx.fragment.app.Fragment
-import com.google.androidstudio.motionlayoutexample.R
+import com.google.androidstudio.motionlayoutexample.databinding.Motion21SecondFragmentBinding
 
 class SecondFragment : Fragment() {
-
-    private lateinit var motionLayout: MotionLayout
 
     companion object {
         fun newInstance() = SecondFragment()
@@ -35,12 +32,7 @@ class SecondFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View {
-        return inflater.inflate(R.layout.motion_21_second_fragment, container, false)
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        motionLayout = view.findViewById(R.id.main)
-        super.onViewCreated(view, savedInstanceState)
+        return Motion21SecondFragmentBinding.inflate(inflater, container, false).root
     }
 
     override fun onStart() {

--- a/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/histogramdemo/HistogramActivity.kt
+++ b/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/histogramdemo/HistogramActivity.kt
@@ -26,7 +26,7 @@ import androidx.annotation.Nullable
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.google.androidstudio.motionlayoutexample.R
-import kotlinx.android.synthetic.main.histogram_layout.*
+import com.google.androidstudio.motionlayoutexample.databinding.HistogramLayoutBinding
 import java.lang.RuntimeException
 import java.util.*
 import kotlin.collections.ArrayList
@@ -46,10 +46,13 @@ class HistogramActivity : AppCompatActivity() {
 
     private val animationGuard: HistogramAnimationGuard = HistogramAnimationGuard()
 
+    private lateinit var binding: HistogramLayoutBinding
+
     override fun onCreate(@Nullable savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.histogram_layout)
-        widget = histogram
+        binding = HistogramLayoutBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        widget = binding.histogram
         restoreView(savedInstanceState)
         widget!!.setTransitionListener(animationGuard.animationListener)
     }
@@ -126,7 +129,7 @@ class HistogramActivity : AppCompatActivity() {
                     throw RuntimeException("Restoring array doesn't match the view size.")
                 }
 
-                bars = ArrayList(bars.mapIndexed{ i, metaData ->
+                bars = ArrayList(bars.mapIndexed { i, metaData ->
                     HistogramBarMetaData(widget!!.barIds[i], metaData)
                 })
                 widget!!.setData(bars)
@@ -150,8 +153,8 @@ class HistogramActivity : AppCompatActivity() {
          * for each bars. It means you cannot use chain feature of constraint layout. You'll need
          * to calculate the after-sorted x location of each bars manually and animate them.
          */
-        sort.setEnabledAndChangeColor(!animationInterruptible)
-        both.setEnabledAndChangeColor(!animationInterruptible)
+        binding.sort.setEnabledAndChangeColor(!animationInterruptible)
+        binding.both.setEnabledAndChangeColor(!animationInterruptible)
     }
 }
 

--- a/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/viewpagerdemo/ViewPagerActivity.kt
+++ b/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/viewpagerdemo/ViewPagerActivity.kt
@@ -20,25 +20,24 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.motion.widget.MotionLayout
 import com.google.androidstudio.motionlayoutexample.R
-import com.google.androidstudio.motionlayoutexample.utils.ViewpagerHeader
-import kotlinx.android.synthetic.main.motion_16_viewpager.*
+import com.google.androidstudio.motionlayoutexample.databinding.Motion16ViewpagerBinding
 
 class ViewPagerActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val layout = R.layout.motion_16_viewpager
-        setContentView(layout)
-        val viewPagerHeader = findViewById<ViewpagerHeader>(R.id.motionLayout)
+        val binding = Motion16ViewpagerBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        val viewPagerHeader = binding.include.motionLayout
 
         val adapter = ViewPagerAdapter(supportFragmentManager)
         adapter.addPage("Page 1", R.layout.motion_16_viewpager_page1)
         adapter.addPage("Page 2", R.layout.motion_16_viewpager_page2)
         adapter.addPage("Page 3", R.layout.motion_16_viewpager_page3)
-        pager.adapter = adapter
-        tabs.setupWithViewPager(pager)
+        binding.pager.adapter = adapter
+        binding.tabs.setupWithViewPager(binding.pager)
         if (viewPagerHeader != null) {
-            pager.addOnPageChangeListener(viewPagerHeader)
+            binding.pager.addOnPageChangeListener(viewPagerHeader)
         }
 
         val debugMode = if (intent.getBooleanExtra("showPaths", false)) {

--- a/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/viewpagerdemo/ViewPagerActivity2.kt
+++ b/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/viewpagerdemo/ViewPagerActivity2.kt
@@ -21,25 +21,23 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.motion.widget.MotionLayout
 import androidx.viewpager.widget.ViewPager
 import com.google.androidstudio.motionlayoutexample.R
-import kotlinx.android.synthetic.main.motion_16_viewpager.*
+import com.google.androidstudio.motionlayoutexample.databinding.Motion23ViewpagerBinding
 
 class ViewPagerActivity2 : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val layout = R.layout.motion_23_viewpager
-        setContentView(layout)
-        val motionLayout = findViewById<MotionLayout>(R.id.motionLayout)
+        val binding = Motion23ViewpagerBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        val motionLayout = binding.include.motionLayout
 
         val adapter = ViewPagerAdapter(supportFragmentManager)
         adapter.addPage("Page 1", R.layout.motion_16_viewpager_page1)
         adapter.addPage("Page 2", R.layout.motion_16_viewpager_page2)
         adapter.addPage("Page 3", R.layout.motion_16_viewpager_page3)
-        pager.adapter = adapter
-        tabs.setupWithViewPager(pager)
-        if (motionLayout != null) {
-            pager.addOnPageChangeListener(motionLayout as ViewPager.OnPageChangeListener)
-        }
+        binding.pager.adapter = adapter
+        binding.tabs.setupWithViewPager(binding.pager)
+        binding.pager.addOnPageChangeListener(motionLayout as ViewPager.OnPageChangeListener)
 
         val debugMode = if (intent.getBooleanExtra("showPaths", false)) {
             MotionLayout.DEBUG_SHOW_PATH

--- a/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/youtubedemo/YouTubeDemoActivity.kt
+++ b/ConstraintLayoutExamples/motionlayout/src/main/java/com/google/androidstudio/motionlayoutexample/youtubedemo/YouTubeDemoActivity.kt
@@ -20,18 +20,15 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.motion.widget.MotionLayout
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import com.google.androidstudio.motionlayoutexample.R
+import com.google.androidstudio.motionlayoutexample.databinding.Motion24YoutubeBinding
 
 class YouTubeDemoActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.motion_24_youtube)
-        val motionLayout = findViewById<MotionLayout>(R.id.motionLayout).apply {
-            savedInstanceState
-        }
-        findViewById<RecyclerView>(R.id.recyclerview_front).apply {
+        val binding = Motion24YoutubeBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        binding.recyclerviewFront.apply {
             adapter = FrontPhotosAdapter()
             isNestedScrollingEnabled = false
             layoutManager = LinearLayoutManager(this@YouTubeDemoActivity)
@@ -41,6 +38,6 @@ class YouTubeDemoActivity : AppCompatActivity() {
         } else {
             MotionLayout.DEBUG_SHOW_NONE
         }
-        motionLayout.setDebugMode(debugMode)
+        binding.motionLayout.setDebugMode(debugMode)
     }
 }

--- a/ConstraintLayoutExamples/motionlayout/src/main/res/layout/motion_16_viewpager.xml
+++ b/ConstraintLayoutExamples/motionlayout/src/main/res/layout/motion_16_viewpager.xml
@@ -14,22 +14,23 @@
   limitations under the License.
   -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="match_parent">
 
-    <include layout="@layout/motion_15_parallax" />
+    <include
+        android:id="@+id/include"
+        layout="@layout/motion_15_parallax" />
 
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/tabs"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@+id/motionLayout">
+        app:layout_constraintTop_toBottomOf="@+id/include">
 
     </com.google.android.material.tabs.TabLayout>
 
     <androidx.viewpager.widget.ViewPager
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/pager"
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/ConstraintLayoutExamples/motionlayout/src/main/res/layout/motion_23_viewpager.xml
+++ b/ConstraintLayoutExamples/motionlayout/src/main/res/layout/motion_23_viewpager.xml
@@ -1,21 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="match_parent">
 
-    <include layout="@layout/motion_23_parallax" />
+    <include
+        android:id="@+id/include"
+        layout="@layout/motion_23_parallax" />
 
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/tabs"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@+id/motionLayout">
+        app:layout_constraintTop_toBottomOf="@+id/include">
 
     </com.google.android.material.tabs.TabLayout>
 
     <androidx.viewpager.widget.ViewPager
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/pager"
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/ConstraintLayoutExamples/motionlayoutintegrations/build.gradle
+++ b/ConstraintLayoutExamples/motionlayoutintegrations/build.gradle
@@ -16,7 +16,6 @@
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 30


### PR DESCRIPTION
- 'motionlayoutintegrations' module is already configured with 'viewBinding', but since the `kotlin-android-extension` plugin has been applied, I consider it to be missing from the previous work and remove it.
- `motionlayout` module is using some `kotlin-android-extension`, so I migrated to viewBinding.