### PR TITLE
Merge pull request #215 from android/update-agp-4-2-1

### DIFF
--- a/RecyclerViewKotlin/app/src/main/java/com/example/recyclersample/flowerList/FlowersAdapter.kt
+++ b/RecyclerViewKotlin/app/src/main/java/com/example/recyclersample/flowerList/FlowersAdapter.kt
@@ -75,10 +75,10 @@ class FlowersAdapter(private val onClick: (Flower) -> Unit) :
 
 object FlowerDiffCallback : DiffUtil.ItemCallback<Flower>() {
     override fun areItemsTheSame(oldItem: Flower, newItem: Flower): Boolean {
-        return oldItem == newItem
+        return oldItem.id == newItem.id
     }
 
     override fun areContentsTheSame(oldItem: Flower, newItem: Flower): Boolean {
-        return oldItem.id == newItem.id
+        return oldItem == newItem
     }
 }


### PR DESCRIPTION
Fix DiffUtil.ItemCallback implementation

The `areItemsTheSame` documentation explicitly says:
"For example, if your items have unique ids, this method should check their id equality."

In the current state, the `DiffUtil.ItemCallback` is implemented wrong.

https://github.com/android/views-widgets-samples/blob/f22069a57d5df0b58ce0be08086c3e9db35870b8/RecyclerViewKotlin/app/src/main/java/com/example/recyclersample/flowerList/FlowersAdapter.kt#L77-L83