### PR TITLE
Fix the diffing logic in FlowerDiffCallback

### DIFF
--- a/RecyclerViewKotlin/app/src/main/java/com/example/recyclersample/flowerList/FlowersAdapter.kt
+++ b/RecyclerViewKotlin/app/src/main/java/com/example/recyclersample/flowerList/FlowersAdapter.kt
@@ -75,10 +75,10 @@ class FlowersAdapter(private val onClick: (Flower) -> Unit) :
 
 object FlowerDiffCallback : DiffUtil.ItemCallback<Flower>() {
     override fun areItemsTheSame(oldItem: Flower, newItem: Flower): Boolean {
-        return oldItem == newItem
+        return oldItem.id == newItem.id
     }
 
     override fun areContentsTheSame(oldItem: Flower, newItem: Flower): Boolean {
-        return oldItem.id == newItem.id
+        return oldItem == newItem
     }
 }


### PR DESCRIPTION
According to the [`DiffUtil.ItemCallback` documentation ](https://developer.android.com/reference/androidx/recyclerview/widget/DiffUtil.ItemCallback#areContentsTheSame(T,%20T)),  and as the names suggest, `areItemsTheSame` should be checking if the IDs are the same and `areContentsTheSame` should be checking if the contents are the same.