### PR TITLE
Fix the KeyTrigger example of MotionLayout where fab is no longer shown after being hidden.

### DIFF
--- a/ConstraintLayoutExamples/motionlayout/src/main/res/xml/scene_25.xml
+++ b/ConstraintLayoutExamples/motionlayout/src/main/res/xml/scene_25.xml
@@ -60,6 +60,10 @@
             android:layout_height="0dp"
             motion:layout_constraintBottom_toBottomOf="parent"
             motion:layout_constraintTop_toBottomOf="@+id/motionLayout" />
+
+        <Constraint android:id="@id/fab">
+            <PropertySet motion:visibilityMode="ignore" />
+        </Constraint>
     </ConstraintSet>
 
     <ConstraintSet android:id="@+id/end">


### PR DESCRIPTION
Fix the `KeyTrigger` example of `MotionLayout` where fab is no longer shown after being hidden.