### PR TITLE
Inverted areItemsTheSame and areContentsTheSame functions

### DIFF
--- a/RecyclerViewKotlin/app/src/main/java/com/example/recyclersample/flowerList/FlowersAdapter.kt
+++ b/RecyclerViewKotlin/app/src/main/java/com/example/recyclersample/flowerList/FlowersAdapter.kt
@@ -75,10 +75,10 @@ class FlowersAdapter(private val onClick: (Flower) -> Unit) :
 
 object FlowerDiffCallback : DiffUtil.ItemCallback<Flower>() {
     override fun areItemsTheSame(oldItem: Flower, newItem: Flower): Boolean {
-        return oldItem == newItem
+        return oldItem.id == newItem.id
     }
 
     override fun areContentsTheSame(oldItem: Flower, newItem: Flower): Boolean {
-        return oldItem.id == newItem.id
+        return oldItem == newItem
     }
 }


### PR DESCRIPTION
The implementations of areContentsTheSame and areItemsTheSame in the original code are swapped, this commit solves that issue.